### PR TITLE
mention pybtex in setup.py as a requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,4 +33,7 @@ setup(
     url="https://github.com/scheunemann/pelican-bib",
     packages=find_packages(),
     classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
+    install_requires=[
+        'pybtex',
+    ],
 )


### PR DESCRIPTION
Hi @scheunemann  and thanks for this handy plugin.

Is there any reason we don't mention `pybtex` as a requirement in `setup.py` – as in this PR – so far?
