### PR TITLE
fix `'docutils.nodes' has no attribute 'reprunicode'` by removing use of long-deprecated docutils' `nodes.reprunicode`

### DIFF
--- a/pelican_bib/bib.py
+++ b/pelican_bib/bib.py
@@ -340,7 +340,6 @@ class Bibliography(Directive):
             )
             source_dir = dirname(abspath(source))
             path = join(source_dir, path)
-        path = nodes.reprunicode(path)
         path = abspath(path)
         return path
 


### PR DESCRIPTION
Finally, `nodes.reprunicode` went away, leading to errors like:

```
Error rendering template `bibliography` (module 'docutils.nodes' has no attribute 'reprunicode').
```

When [last seen](https://sourceforge.net/p/docutils/code/9415/), `nodes.reprunicode` has been a wrapper around ``str``.

Thanks for considering.